### PR TITLE
translate tramp path when remote

### DIFF
--- a/blamer.el
+++ b/blamer.el
@@ -26,7 +26,7 @@
 
 ;;; Code:
 
-(require 'file)
+(require 'files)
 (require 'subr-x)
 (require 'simple)
 (require 'time-date)


### PR DESCRIPTION
TRAMP buffers will have a name like: /method:user@host:/path/to/file

When constructing the git command we want to only use the local name (/path/to/file)