### PR TITLE
Handle empty strings when git author is undefined

### DIFF
--- a/blamer.el
+++ b/blamer.el
@@ -407,8 +407,7 @@ will appear after BLAMER-IDLE-TIME. It works only inside git repo"
     (when (and (not blamer--current-author)
                blamer-author-formatter
                is-git-repo)
-      (setq-local blamer--current-author (substring (shell-command-to-string blamer--git-author-cmd) 0 -1)))
-
+      (setq-local blamer--current-author (replace-regexp-in-string "\n\\'" "" (shell-command-to-string blamer--git-author-cmd))))
     (if (and blamer-mode (buffer-file-name) is-git-repo)
         (progn
           (add-hook 'post-command-hook #'blamer--try-render nil t))


### PR DESCRIPTION
When the git author is undefined substring will error as it cannot index (0 -1) .

I believe this code exists to strip the newline from the shell, so I've used with replace-regexp-in-string which will handle the undefined case as well.