### PR TITLE
Tooltip about blamer bindings

### DIFF
--- a/README.org
+++ b/README.org
@@ -138,7 +138,24 @@ For example, if we want to open magit diff by left click, and browse remote by r
                           ("<mouse-1>" . blamer-callback-show-commit-diff)))
 #+END_SRC
 
-
+Also, you can use [[https://github.com/emacsmirror/git-timemachine][timemachine]] or select the commit in the magit log: 
+#+BEGIN_SRC emacs-lisp
+  (defun blamer-callback-magit-log-file (commit-info)
+    (interactive)
+    (magit-log-buffer-file)
+    (let ((commit-hash (plist-get commit-info :commit-hash)))
+      (when commit-hash
+        (run-with-idle-timer 1 nil (lambda (commit-hash)
+                                     (goto-char (point-min))
+                                     (search-forward (substring commit-hash 0 7))
+                                     (set-mark (point-at-bol))
+                                     (goto-char (point-at-eol)))
+                             commit-hash))))
+  
+  (defun blamer-callback-timemachine (commit-info)
+    (interactive)
+    (git-timemachine))
+#+END_SRC
 * Contribute
 Run before push
 #+BEGIN_SRC bash

--- a/README.org
+++ b/README.org
@@ -117,7 +117,8 @@ commit-info consist of:
 =:raw-commit-author= - raw author username if exist.
 =:commit-date= - date of commit. (string field)
 =:commit-time= - commit's time. (string field)
-=:commit-message= - message of commit. If not exist will be get from
+=:commit-message= - message of commit. If not exist will be get from =blamer-uncommitted-changes-message=
+=:raw-commit-message= - full message of commit.
 For example, if we want to open magit diff by left click, and browse remote by right click we can use this code (magit and forge have to be installed):
 
 #+BEGIN_SRC emacs-lisp

--- a/blamer.el
+++ b/blamer.el
@@ -220,15 +220,6 @@ author name by left click and copying commit hash by right click.
       (mapconcat (lambda (bind) (format "%s - %s" (car bind) (cdr bind))) blamer-bindings "\n")
      nil))
 
-(defun blamer--apply-tooltip(text commit-info)
-  "Compute the toolip from `blamer-tooltip-function' and COMMIT-INFO."
-  (let ((help-echo (if (and blamer-tooltip-function (functionp blamer-tooltip-function))
-                          (funcall blamer-tooltip-function commit-info)
-                        nil)))
-    (if help-echo
-        (propertize text 'help-echo help-echo 'pointer 'hand)
-      text)))
-
 (defun blamer--git-exist-p ()
   "Return t if .git exist."
   (let* ((git-exist-stdout (shell-command-to-string blamer--git-repo-cmd)))
@@ -330,9 +321,8 @@ COMMIT-INFO - all the commit information, for `blamer--apply-bindings'"
                                                (a-merge (face-all-attributes 'blamer-face (selected-frame))
                                                         `((:background ,(blamer--get-background-color)))))
                                         'cursor t))
-         ;; I don't know, might be we can combine this two operations, cause its also redundant a bit
          (formatted-message (blamer--apply-tooltip formatted-message commit-info))
-         (formatted-message (blamer--apply-bindings formatted-message commit-info)) ;; apply bindings only to text, not offset
+         (formatted-message (blamer--apply-bindings formatted-message commit-info))
          (additional-offset (if blamer-offset-per-symbol
                                 (/ (string-width formatted-message) blamer-offset-per-symbol) 0))
          ;; NOTE https://github.com/Artawower/blamer.el/issues/8
@@ -425,10 +415,18 @@ Return nil if error."
        (tramp-dissect-file-name filename))
     filename))
 
+(defun blamer--apply-tooltip(text commit-info)
+  "Compute the toolip from `blamer-tooltip-function' and COMMIT-INFO."
+  (let ((help-echo (if (and blamer-tooltip-function (functionp blamer-tooltip-function))
+                          (funcall blamer-tooltip-function commit-info)
+                        nil)))
+    (if help-echo
+        (propertize text 'help-echo help-echo 'pointer 'hand)
+      text)))
+
 (defun blamer--apply-bindings (text commit-info)
   "Apply defined bindings to TEXT and pass COMMIT-INFO to callback."
   (let ((map (make-sparse-keymap)))
-
     (dolist (mapbind blamer-bindings)
       (define-key map (kbd (car mapbind))
         (lambda ()

--- a/blamer.el
+++ b/blamer.el
@@ -391,14 +391,16 @@ Return nil if error."
 (defun blamer--apply-bindings (text commit-info)
   "Apply defined bindings to TEXT and pass COMMIT-INFO to callback."
   (let ((map (make-sparse-keymap))
-        (help-echo (mapconcat (lambda (bind) (format "%s - %s" (car bind) (cdr bind))) blamer-bindings "\n")))
-    
+        (help-echo (if (> (length blamer-bindings) 0)
+                       (mapconcat (lambda (bind) (format "%s - %s" (car bind) (cdr bind))) blamer-bindings "\n")
+                     "Add custom mouse bindngs customizing blamer-bindings")))
+
     (dolist (mapbind blamer-bindings)
       (define-key map (kbd (car mapbind))
         (lambda ()
           (interactive)
-          (funcall (cdr mapbind) commit-info)))
-      (setq text (propertize text 'keymap map 'help-echo help-echo 'pointer 'hand))))
+          (funcall (cdr mapbind) commit-info))))
+    (setq text (propertize text 'keymap map 'help-echo help-echo 'pointer 'hand)))
   text)
 
 (defun blamer--render ()

--- a/blamer.el
+++ b/blamer.el
@@ -283,7 +283,7 @@ AUTHOR - name of commiter
 DATE - date in format YYYY-DD-MM
 TIME - time in format HH:MM:SS
 OFFSET - additional offset for commit message
-COMMIT-INFO - all the commit information, for blamer--apply-bindings"
+COMMIT-INFO - all the commit information, for `blamer--apply-bindings'"
   (ignore commit-hash)
 
   (let* ((uncommitted (string= author "Not Committed Yet"))

--- a/blamer.el
+++ b/blamer.el
@@ -222,7 +222,7 @@ author name by left click and copying commit hash by right click.
   "This function can be use as `blamer-tooltip-function', to show the available `blamer-bindings'."
   (if (> (length blamer-bindings) 0)
       (mapconcat (lambda (bind) (format "%s - %s" (car bind) (cdr bind))) blamer-bindings "\n")
-    "Add custom mouse bindngs customizing blamer-bindings"))
+    nil))
 
 (defun blamer--get-tooltip(commit-info)
   "Compute the toolip from `blamer-tooltip-function' and COMMIT-INFO."


### PR DESCRIPTION
Added a tooltip with information about `blamer-bindings`.
The tooltip shows the current bindings, or a message about customizing `blamer-bindings`

![image](https://user-images.githubusercontent.com/1097236/142761947-7cde96ef-45b1-4fa8-a2ad-81d927898af6.png)

Also, added two more binding examples in readme.