### PR TITLE
Fix typo in key binding configuration

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,7 +16,7 @@ A git blame plugin for emacs inspired by [[https://marketplace.visualstudio.com/
 (use-package blamer
   :ensure t
   :bind (("s-i" . blamer-show-commit-info)
-         ("C-c i" . ("s-i" . blamer-show-posframe-commit-info)))
+         ("C-c i" . blamer-show-posframe-commit-info))
   :defer 20
   :custom
   (blamer-idle-time 0.3)


### PR DESCRIPTION
If I eval melpa configuration, I get
```lisp
Debugger entered--Lisp error: (error "use-package: blamer wants arguments acceptable to the `bind-keys' macro, or a list of such values")
...
```
Since `bind-keys` help says
```txt
...The rest of the arguments are conses of keybinding string and a function symbol...
```
I'm guessing that the double cons might be a typo.

If this is so, some other configuration snippet can suffer the same issue, but I'm not very fluent in elisp and I can be wrong, so please feel free to disregard this PR :slightly_smiling_face: 