### PR TITLE
feat: Add echo-area as a rendering option

### DIFF
--- a/README.org
+++ b/README.org
@@ -122,6 +122,8 @@ Can accept
 - ='overlay-popup= - nice overlay popup (see images/blamer-pretty-popup-dark.jpg)
 - ='margin-overlay= - show commit info in the margin
 - ='posframe-popup= - posframe popup (see images/posframe.png)
+- ='echo-area= - show commit info for the current line in the echo area.
+
   *Warning* The 'overlay-popup feature highly dependent on you custom fonts, it may have worse alignment.
 **** Overlay popup position
 =blamer--overlay-popup-position= - is position for the overlay popup, it could be:
@@ -179,8 +181,12 @@ If you have an incorrect view of the avatar or line breaks, try to play with the
 
 Useful for self-hosted Gitlab or GitHub instances.
 
+**** Echo area
+/Echo area specific customizations/
 
+~blamer-echo-area-inset~ - number of leading characters the remove when rendering in the echo area.
 
+~blamer-echo-area-strip-face-attributes~ - list of face-attributes to remove when rendering in the echo area.
 
 * Interactive binding
 You can bind the mouse click event and pass custom handler. Where the handler is callback function with commit-info arg.

--- a/blamer.el
+++ b/blamer.el
@@ -41,8 +41,8 @@
 
 (defconst blamer--regexp-info
   (concat "^\\(?1:[^ ]*\\) \\(?5:[^ ]* \\)?(\\(?2:.*\\)"
-	        "\s\\(?3:[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}\\)"
-	        "\s\\(?4:[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\)")
+	      "\s\\(?3:[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}\\)"
+	      "\s\\(?4:[0-9]\\{2\\}:[0-9]\\{2\\}:[0-9]\\{2\\}\\)")
 
   "Regexp for extract data from blame message.
 1 - commit hash
@@ -112,6 +112,16 @@
 Will add additional space for each BLAMER-OFFSET-PER-SYMBOL"
   :group 'blamer
   :type 'integer)
+
+(defcustom blamer-echo-area-inset 3
+  ""
+  :group 'blamer
+  :type 'integer)
+
+(defcustom blamer-echo-area-strip-face-attributes '(:background)
+  ""
+  :group 'blamer
+  :type '(repeat face-attribute))
 
 (defcustom blamer-type 'both
   "Type of blamer.
@@ -880,9 +890,21 @@ Return list of strings."
     (add-to-list 'blamer--overlays ov)))
 
 (defun blamer--render-echo-area (commit-info)
-  (let* ((popup (string-trim (blamer--create-popup-msg commit-info t)))
-         (msg (substring-no-properties popup)))
-    (message msg)))
+  (let* ((msg (blamer--format-commit-info (plist-get commit-info :commit-hash)
+                                          (plist-get commit-info :commit-message)
+                                          (plist-get commit-info :commit-author)
+                                          (plist-get commit-info :commit-date)
+                                          (plist-get commit-info :commit-time)
+                                          0
+                                          commit-info))
+         (msg (substring msg blamer-echo-area-inset))
+         (face-props (get-text-property 0 'face msg)))
+
+    (dolist (prop blamer-echo-area-strip-face-attributes  nil)
+      (plist-put face-props prop (face-attribute 'default prop)))
+    (put-text-property 0 (length msg) 'face face-props msg)
+
+    (message "%s" msg)))
 
 (defun blamer--render-right-overlay (commit-info render-point)
   "Render COMMIT-INFO as overlay at RENDER-POINT position."

--- a/blamer.el
+++ b/blamer.el
@@ -129,7 +129,8 @@ This types are used only for single line blame.
                  (const :tag "Pretty posframe popup" posframe-popup)
                  (const :tag "Visual and selected" both)
                  (const :tag "Margin overlay" margin-overlay)
-                 (const :tag "Selected only" selected)))
+                 (const :tag "Selected only" selected)
+                 (const :tag "Echo area" echo-area)))
 
 (defcustom blamer--overlay-popup-position 'bottom
   "Position of rendered popup.
@@ -878,6 +879,11 @@ Return list of strings."
     (overlay-put ov 'window (get-buffer-window))
     (add-to-list 'blamer--overlays ov)))
 
+(defun blamer--render-echo-area (commit-info)
+  (let* ((popup (string-trim (blamer--create-popup-msg commit-info t)))
+         (msg (substring-no-properties popup)))
+    (message msg)))
+
 (defun blamer--render-right-overlay (commit-info render-point)
   "Render COMMIT-INFO as overlay at RENDER-POINT position."
   (when-let ((ov (progn (move-end-of-line nil)
@@ -943,6 +949,7 @@ when not provided `blamer-type' will be used."
   (with-current-buffer buffer
     (save-excursion
       (cond ((eq (or type blamer-type) 'overlay-popup) (blamer--render-overlay-popup commit-info))
+            ((eq (or type blamer-type) 'echo-area) (blamer--render-echo-area commit-info))
             ((eq (or type blamer-type) 'posframe-popup) (blamer--render-posframe-popup commit-info))
             ((eq (or type blamer-type) 'margin-overlay) (blamer--render-margin-overlay commit-info render-point))
             (t (blamer--render-right-overlay commit-info render-point))))))
@@ -1051,7 +1058,8 @@ Optional TYPE argument will override global `blamer-type'."
   (let ((blamer-type (or type blamer-type))
         (long-region-p (blamer--long-region-p)))
     (unless (or (and (or (eq blamer-type 'overlay-popup)
-                         (eq blamer-type 'visual))
+                         (eq blamer-type 'visual)
+                         (eq blamer-type 'echo-area))
                      (use-region-p))
                 long-region-p
                 blamer--block-render-p)
@@ -1096,7 +1104,8 @@ LOCAL-TYPE is force replacement of current `blamer-type' for handle rendering."
                    (eq type 'margin-overlay)
                    (and (eq type 'visual) (not (use-region-p)))
                    (and (eq type 'overlay-popup) (not (use-region-p)))
-                   (and (eq type 'selected) (use-region-p)))
+                   (and (eq type 'selected) (use-region-p))
+                   (eq type 'echo-area))
                (or (not blamer--previous-line-number)
                    (not (eq blamer--previous-window-width (blamer--real-window-width)))
                    (not (eq blamer--previous-line-number (line-number-at-pos)))

--- a/blamer.el
+++ b/blamer.el
@@ -113,16 +113,6 @@ Will add additional space for each BLAMER-OFFSET-PER-SYMBOL"
   :group 'blamer
   :type 'integer)
 
-(defcustom blamer-echo-area-inset 3
-  ""
-  :group 'blamer
-  :type 'integer)
-
-(defcustom blamer-echo-area-strip-face-attributes '(:background)
-  ""
-  :group 'blamer
-  :type '(repeat face-attribute))
-
 (defcustom blamer-type 'both
   "Type of blamer.
 \\='visual - show blame only for current line
@@ -336,6 +326,21 @@ May be useful in some cases where the accuser unexpectedly
 moves to the next line."
   :group 'blamer
   :type 'integer)
+
+(defcustom blamer-echo-area-inset 3
+  "Number of prefix characters to remove from the formatted
+commit message in echo-area. This is a workaround to use the same format
+for both overlay and echo-area, while both look good."
+  :group 'blamer
+  :type 'integer)
+
+(defcustom blamer-echo-area-strip-face-attributes '(:background)
+  "A list of face-attributes to remove when printing COMMIT-INFO to
+the echo-area. This is a workaround for using the same format for
+both overlay echo-area while removing e.g. :background, to look good
+in the echo-area."
+  :group 'blamer
+  :type '(repeat symbol))
 
 (defvar blamer-idle-timer nil
   "Current timer before commit info showing.")
@@ -890,6 +895,7 @@ Return list of strings."
     (add-to-list 'blamer--overlays ov)))
 
 (defun blamer--render-echo-area (commit-info)
+  "Render COMMIT-INFO in the echo-area"
   (let* ((msg (blamer--format-commit-info (plist-get commit-info :commit-hash)
                                           (plist-get commit-info :commit-message)
                                           (plist-get commit-info :commit-author)
@@ -897,10 +903,10 @@ Return list of strings."
                                           (plist-get commit-info :commit-time)
                                           0
                                           commit-info))
-         (msg (substring msg blamer-echo-area-inset))
+         (msg (substring msg (or blamer-echo-area-inset 0)))
          (face-props (get-text-property 0 'face msg)))
 
-    (dolist (prop blamer-echo-area-strip-face-attributes  nil)
+    (dolist (prop blamer-echo-area-strip-face-attributes nil)
       (plist-put face-props prop (face-attribute 'default prop)))
     (put-text-property 0 (length msg) 'face face-props msg)
 

--- a/blamer.el
+++ b/blamer.el
@@ -909,8 +909,8 @@ Return list of strings."
     (dolist (prop blamer-echo-area-strip-face-attributes nil)
       (plist-put face-props prop (face-attribute 'default prop)))
     (put-text-property 0 (length msg) 'face face-props msg)
-
-    (message "%s" msg)))
+    (let ((message-log-max nil))
+      (message "%s" msg))))
 
 (defun blamer--render-right-overlay (commit-info render-point)
   "Render COMMIT-INFO as overlay at RENDER-POINT position."


### PR DESCRIPTION
This adds the option to render the commit message to the echo area by setting `blamer-type` to `'echo-area`

<img width="930" height="487" alt="Screenshot From 2025-08-29 22-15-46" src="https://github.com/user-attachments/assets/493e95e5-8427-42d1-ac93-13a82a20dd4e" />

The only added function is `blamer--render-echo-area` which just creates the normally formatted commit-info, modifies it by removing some leading spaces, text-face-attributes and then writes it with `message`.

There are also two new custom variables:
- `blamer-echo-area-inset`. Controls how many leading characters to remove, defaults to 3 matching the default to `blamer-entire-formatter`. Removing leading spaces is done to have the same format as the overlay, but still looking good in the echo area.
- `blamer-echo-area-strip-face-attributes`. List of faces to strip from the text-face-attributes of the formatted commit-info string. This is again done to remove for example the background to look good with the default format. The default value is `'(:background)` to only remove background color.

Recommended minimal config:
```elisp
(use-package blamer
  :custom ((blamer-type 'echo-area)
           (blamer-max-commit-message-length (window-body-width (minibuffer-window))))
  :config (global-blamer-mode))
```

or a bit more verbose one:
```elisp

(use-package blamer
  :custom ((blamer-idle-time 0.5)
           (blamer-type 'echo-area)
           (blamer-echo-area-inset 3)
           (blamer-echo-area-strip-face-attributes '(:background :foreground))
           (blamer-max-commit-message-length (window-body-width (minibuffer-window))))
  :config (global-blamer-mode))
```

Also updated README documentation.